### PR TITLE
Hide default modules and lessons on single course pages

### DIFF
--- a/sensei-lesson-grid.php
+++ b/sensei-lesson-grid.php
@@ -557,7 +557,7 @@ class SLGE_Plugin {
         // Hide Sensei default modules/lessons on single course if opted in
         $hide_default = get_post_meta( $grid_post->ID, '_slg_hide_sensei_default', true );
         if ( $hide_default && function_exists( 'is_singular' ) && is_singular( 'course' ) ) {
-            echo '<style>body.single-course .sensei-course-content, body.single-course .course-lessons, body.single-course .course-lesson-list{display:none!important}</style>';
+            echo '<style>body.single-course .sensei-course-content, body.single-course .course-lessons, body.single-course .course-lesson-list, body.single-course .course .modules-title, body.single-course .course .module{display:none!important}</style>';
         }
 
         // Debug information for admins


### PR DESCRIPTION
## Summary
- Suppress Sensei's built-in course content by adding `.course .modules-title` and `.course .module` to the hidden selectors on single course pages

## Testing
- `php -l sensei-lesson-grid.php`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b733bcf404832eadb4c117a44ddb0b